### PR TITLE
Rename filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ once the API is stable.
 
 ## Unreleased
 
+- CHANGED: Renamed `filters.command_blacklist` to `filters.deny`.
+
+- CHANGED: Renamed `filters.command_whitelist` to `filters.allow`.
+
 - CHANGED: `ReceivedMessage.suffix`
 
   This is no longer a unicode string, as it was too presumptious to guess the

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ quips = {
 }
 
 
-@filters.command_whitelist(PRIVMSG)
+@filters.allow(PRIVMSG)
 def snarky_response(client, message):
     # See section "Still to come" for ideas on how this could be simplified.
     sender = message.prefix.split('!')[0]
@@ -125,9 +125,9 @@ decision about how they will deal with the message.
 
 As most of your handlers will not need to deal with every message that comes
 in, we can remove the boilerplate of `if message.command == MYCOMMAND` through
-use of the decorators in the `filters` module. The `command_whitelist` filter
-only allows messages through to the handler that are in its whitelist. The
-`command_blacklist` does the opposite. eg:
+use of the decorators in the `filters` module. The `allow` filter only allows
+messages through to the handler that are in its whitelist. The `deny` filter
+does the opposite. eg:
 
 ```python
 # Rather than this:
@@ -137,7 +137,7 @@ def my_command_handler(client, message):
     do_useful_logic(message)
 
 # It's nicer to have this:
-@command_whitelist(MYCOMMAND):
+@allow(MYCOMMAND):
 def my_simpler_command_handler(client, message):
     do_useful_logic(message)
 ```

--- a/framewirc/filters.py
+++ b/framewirc/filters.py
@@ -1,17 +1,17 @@
-def command_blacklist(blacklist):
+def deny(blacklist):
     """
     Decorates a handler to filter out a blacklist of commands.
 
     The decorated handler will not be called if message.command is in the
     blacklist:
 
-        @command_blacklist(['A', 'B'])
+        @deny(['A', 'B'])
         def handle_everything_except_a_and_b(client, message):
             pass
 
     Single-item blacklists may be passed as a string:
 
-        @command_blacklist('THIS')
+        @deny('THIS')
         def handle_everything_except_this(client, message):
             pass
     """
@@ -25,20 +25,20 @@ def command_blacklist(blacklist):
     return inner_decorator
 
 
-def command_whitelist(whitelist):
+def allow(whitelist):
     """
     Decorates a handler to filter all except a whitelist of commands
 
     The decorated handler will only be called if message.command is in the
     whitelist:
 
-        @command_whitelist(['A', 'B'])
+        @allow(['A', 'B'])
         def handle_only_a_and_b(client, message):
             pass
 
     Single-item whitelists may be passed as a string:
 
-        @command_whitelist('THIS')
+        @allow('THIS')
         def handle_only_this(client, message):
             pass
     """

--- a/framewirc/handlers.py
+++ b/framewirc/handlers.py
@@ -2,14 +2,14 @@ from . import commands, filters
 from .message import build_message
 
 
-@filters.command_whitelist(commands.PING)
+@filters.allow(commands.PING)
 def ping(client, message):
     """On recieving PING, repond with PONG."""
     payload = build_message('PONG', suffix=message.suffix)
     client.connection.send(payload)
 
 
-@filters.command_whitelist(commands.ERR_NICKNAMEINUSE)
+@filters.allow(commands.ERR_NICKNAMEINUSE)
 def nickname_in_use(client, message):
     """If nick is being used, append a caret."""
     client.set_nick(client.nick + '^')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -4,7 +4,7 @@ from framewirc import filters
 from framewirc.message import ReceivedMessage
 
 
-class TestCommandBlacklist(TestCase):
+class TestDeny(TestCase):
     def setUp(self):
         self.client = object()
         self.handler = mock.Mock()
@@ -12,7 +12,7 @@ class TestCommandBlacklist(TestCase):
     def test_correct_list(self):
         """Un-blacklisted commands should be allowed."""
         message = ReceivedMessage(b'COMMAND\r\n')
-        wrapped = filters.command_blacklist(['WRONG_COMMAND'])(self.handler)
+        wrapped = filters.deny(['WRONG_COMMAND'])(self.handler)
 
         wrapped(self.client, message)
 
@@ -24,7 +24,7 @@ class TestCommandBlacklist(TestCase):
     def test_incorrect_list(self):
         """Blacklisted commands should not be allowed."""
         message = ReceivedMessage(b'WRONG_COMMAND\r\n')
-        wrapped = filters.command_blacklist(['WRONG_COMMAND'])(self.handler)
+        wrapped = filters.deny(['WRONG_COMMAND'])(self.handler)
 
         wrapped(self.client, message)
 
@@ -33,7 +33,7 @@ class TestCommandBlacklist(TestCase):
     def test_correct_item(self):
         """Un-blacklisted commands should be allowed (string blacklist)."""
         message = ReceivedMessage(b'COMMAND\r\n')
-        wrapped = filters.command_blacklist('WRONG_COMMAND')(self.handler)
+        wrapped = filters.deny('WRONG_COMMAND')(self.handler)
 
         wrapped(self.client, message)
 
@@ -45,14 +45,14 @@ class TestCommandBlacklist(TestCase):
     def test_incorrect_item(self):
         """Blacklisted commands should not be allowed (string blacklist)."""
         message = ReceivedMessage(b'WRONG_COMMAND\r\n')
-        wrapped = filters.command_blacklist('WRONG_COMMAND')(self.handler)
+        wrapped = filters.deny('WRONG_COMMAND')(self.handler)
 
         wrapped(self.client, message)
 
         self.assertFalse(self.handler.called)
 
 
-class TestCommandWhitelist(TestCase):
+class TestAllow(TestCase):
     def setUp(self):
         self.client = object()
         self.handler = mock.Mock()
@@ -60,7 +60,7 @@ class TestCommandWhitelist(TestCase):
     def test_correct_list(self):
         """Whitelisted commands should be allowed."""
         message = ReceivedMessage(b'COMMAND\r\n')
-        wrapped = filters.command_whitelist(['COMMAND'])(self.handler)
+        wrapped = filters.allow(['COMMAND'])(self.handler)
 
         wrapped(self.client, message)
 
@@ -72,7 +72,7 @@ class TestCommandWhitelist(TestCase):
     def test_incorrect_list(self):
         """Unlisted commands should not be allowed."""
         message = ReceivedMessage(b'WRONG_COMMAND\r\n')
-        wrapped = filters.command_whitelist(['COMMAND'])(self.handler)
+        wrapped = filters.allow(['COMMAND'])(self.handler)
 
         wrapped(self.client, message)
 
@@ -81,7 +81,7 @@ class TestCommandWhitelist(TestCase):
     def test_correct_item(self):
         """Whitelisted commands should be allowed (string whitelist)."""
         message = ReceivedMessage(b'COMMAND\r\n')
-        wrapped = filters.command_whitelist('COMMAND')(self.handler)
+        wrapped = filters.allow('COMMAND')(self.handler)
 
         wrapped(self.client, message)
 
@@ -93,7 +93,7 @@ class TestCommandWhitelist(TestCase):
     def test_incorrect_item(self):
         """Unlisted commands should not be allowed (string whitelist)."""
         message = ReceivedMessage(b'WRONG_COMMAND\r\n')
-        wrapped = filters.command_whitelist('COMMAND')(self.handler)
+        wrapped = filters.allow('COMMAND')(self.handler)
 
         wrapped(self.client, message)
 
@@ -102,7 +102,7 @@ class TestCommandWhitelist(TestCase):
     def test_incorrect_subitem(self):
         """Partial commands should not be allowed (string whitelist)."""
         message = ReceivedMessage(b'COMMA\r\n')
-        wrapped = filters.command_whitelist('COMMAND')(self.handler)
+        wrapped = filters.allow('COMMAND')(self.handler)
 
         wrapped(self.client, message)
 


### PR DESCRIPTION
It might be clearer what the filters do if they were better named.

`command_blacklist`  -> `deny`
`command_whitelist` -> `only`

Is this an improvement?