### PR TITLE
Add nick parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This project is in alpha. I plan to adhere to [semantic versioning][semver]
 once the API is stable.
 
+## Unreleased
+
+- ADDED: `parsers.nick`.
+
+  A function that takes a `nick!ident@host` string (or similar), and returns a
+  dictionary of components.
+
+
 ## v0.0.1
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ from framewirc import filters
 from framewirc.client import Client
 from framewirc.commands import PRIVMSG
 from framewirc.handlers import basic_handlers
+from framewirc.parsers import nick
 
 
 quips = {
@@ -40,7 +41,7 @@ quips = {
 @filters.command_whitelist(PRIVMSG)
 def snarky_response(client, message):
     # See section "Still to come" for ideas on how this could be simplified.
-    sender = message.prefix.split('!')[0]
+    sender = nick(message.prefix)['nick']
     text = message.suffix
 
     for trigger, reposte in quips.items():

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -1,0 +1,25 @@
+def nick(raw_nick):
+    """
+    Split nick into constituent parts.
+
+    Nicks with an ident are in the following format:
+
+        nick!ident@hostname
+
+    When they don't have an ident, they have a leading tilde instead:
+
+        ~nick@hostname
+    """
+
+    if '!' in raw_nick:
+        nick, _rest = raw_nick.split('!')
+        ident, host = _rest.split('@')
+    else:
+        nick, host = raw_nick.split('@')
+        nick = nick.lstrip('~')
+        ident = None
+    return {
+        'nick': nick,
+        'ident': ident,
+        'host': host,
+    }

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -10,7 +10,6 @@ def nick(raw_nick):
 
         ~nick@hostname
     """
-
     if '!' in raw_nick:
         nick, _rest = raw_nick.split('!')
         ident, host = _rest.split('@')

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from framewirc.parsers import nick
+
+
+class TestNick(TestCase):
+    """The nick parser can deal with several nick formats."""
+    def test_nick_with_ident(self):
+        raw_nick = 'nickname!ident@hostname'
+
+        result = nick(raw_nick)
+
+        expected = {
+            'nick': 'nickname',
+            'ident': 'ident',
+            'host': 'hostname',
+        }
+        self.assertEqual(result, expected)
+
+    def test_nick_without_ident(self):
+        raw_nick = '~nickname@hostname'
+
+        result = nick(raw_nick)
+
+        expected = {
+            'nick': 'nickname',
+            'ident': None,
+            'host': 'hostname',
+        }
+        self.assertEqual(result, expected)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -6,9 +6,7 @@ from framewirc.parsers import nick
 class TestNick(TestCase):
     """The nick parser can deal with several nick formats."""
     def test_nick_with_ident(self):
-        raw_nick = 'nickname!ident@hostname'
-
-        result = nick(raw_nick)
+        result = nick('nickname!ident@hostname')
 
         expected = {
             'nick': 'nickname',
@@ -18,9 +16,7 @@ class TestNick(TestCase):
         self.assertEqual(result, expected)
 
     def test_nick_without_ident(self):
-        raw_nick = '~nickname@hostname'
-
-        result = nick(raw_nick)
+        result = nick('~nickname@hostname')
 
         expected = {
             'nick': 'nickname',


### PR DESCRIPTION
Sometimes it's nicer to have `nick, ident, host` split up from the standard format of `nick!ident@host`.

Not sure if this should be a dictionary, a tuple, an object, or a namedtuple.