### PR TITLE
Add message parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ once the API is stable.
   A function that takes a `nick!ident@host` string (or similar), and returns a
   dictionary of components.
 
+- ADDED: `parsers.privmsg`.
+
+  A function that splits a `PRIVMSG` command into a dictionary of semantically
+  named attributes.
+
 
 ## v0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ once the API is stable.
 
 ## Unreleased
 
+- CHANGED: `ReceivedMessage.suffix`
+
+  This is no longer a unicode string, as it was too presumptious to guess the
+  encoding. This is now left to the programmer to decide, allowing them to do
+  things such as change default encoding per channel.
+
 - ADDED: `parsers.is_channel`.
 
   A function to determine of a string is a valid channel name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ once the API is stable.
 
 ## Unreleased
 
+- ADDED: `parsers.is_channel`.
+
+  A function to determine of a string is a valid channel name.
+
 - ADDED: `parsers.nick`.
 
   A function that takes a `nick!ident@host` string (or similar), and returns a

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ messages in both directions must adhere to the (simple) rules:
 
   We represent the messages that come from the network with our own subclass of
   `bytes` called `ReceivedMessage`. It has `prefix`, `command`, `parameters`,
-  and `suffix` added for convinience. Each of these attributes represents the
-  relevant message parts as a unicode string (except `parameters`, which is a
-  tuple of strings).
+  and `suffix` added for convinience. The `prefix` and `command` parts are
+  represented as unicode strings, `parameters`is a tuple of unicode strings,
+  but `suffix` is a bytestring. This allows for custom logic in decoding
+  arbitrary text from the network.
 
 - Messages have a maximum length of 512 bytes.
 

--- a/framewirc/message.py
+++ b/framewirc/message.py
@@ -18,22 +18,23 @@ class ReceivedMessage(bytes):
 
         Adapted from http://stackoverflow.com/a/930706/400691
         """
-        message = to_unicode(self.strip())
+        message = self.rstrip()
 
-        prefix = ''
+        prefix = b''
         # Odd slicing required for bytes to avoid getting int instead of char
         # http://stackoverflow.com/q/28249597/400691
-        if message[0:1] == ':':
-            prefix, message = message[1:].split(' ', 1)
+        if message[0:1] == b':':
+            prefix, message = message[1:].split(b' ', 1)
 
-        suffix = ''
-        if ' :' in message:
-            message, suffix = message.split(' :', 1)
+        suffix = b''
+        if b' :' in message:
+            message, suffix = message.split(b' :', 1)
 
         command, *params = message.split()
-        params = tuple(filter(None, params))
+        params = tuple(to_unicode(p) for p in params if p)
 
-        return prefix, command, params, suffix
+        # Suffix not yet turned to unicode to allow more complex encoding logic
+        return to_unicode(prefix), to_unicode(command), params, suffix
 
 
 def build_message(command, *args, prefix=b'', suffix=b''):

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -46,3 +46,28 @@ def nick(raw_nick):
         'ident': ident,
         'host': host,
     }
+
+
+def privmsg(message):
+    """
+    Split received PRIVMSG command into a dictionary of parts.
+
+    When the message target is a channel, 'channel' is set to that. Otherwise,
+    'channel' is defined as the sender's nick.
+    """
+    target = message.params[0]
+    raw_sender = message.prefix
+    sender_nick = nick(raw_sender)['nick']
+
+    if is_channel(target):
+        channel = target
+    else:
+        channel = sender_nick
+
+    return {
+        'channel': channel,
+        'raw_body': message.suffix,
+        'raw_sender': raw_sender,
+        'sender_nick': sender_nick,
+        'target': target,
+    }

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -1,3 +1,27 @@
+def is_channel(name):
+    """
+    Determine if a string is a valid channel name.
+
+    The exact text from RFC2812 §1.3 is as follows:
+
+    Channels names are strings (beginning with a '&', '#', '+' or '!'
+    character) of length up to fifty (50) characters.  Apart from the
+    requirement that the first character is either '&', '#', '+' or '!',
+    the only restriction on a channel name is that it SHALL NOT contain
+    any spaces (' '), a control G (^G or ASCII 7), a comma (',').  Space
+    is used as parameter separator and command is used as a list item
+    separator by the protocol).  A colon (':') can also be used as a
+    delimiter for the channel mask.  Channel names are case insensitive.
+    """
+    if len(name) > 50:
+        return False
+    if set(name).intersection(',\7 '):  # Note the space
+        return False
+    if name[0] not in '&#+!':
+        return False
+    return True
+
+
 def nick(raw_nick):
     """
     Split nick into constituent parts.

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -33,7 +33,7 @@ class TestReceivedMessage(TestCase):
 
                 expected_prefix = 'prefixed-data' if prefix else ''
                 expected_params = ('param1', 'param2') if params else ()
-                expected_suffix = 'suffix message' if suffix else ''
+                expected_suffix = b'suffix message' if suffix else b''
 
                 self.assertEqual(message.command, 'COMMAND')
                 self.assertEqual(message.prefix, expected_prefix)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -15,7 +15,7 @@ class TestIsChannel(TestCase):
         self.assertTrue(is_channel('!channel'))
 
     def test_starts_with_hash(self):
-        """True when starts with a # ("hash", AKA "pound")."""
+        """True when starts with a # ("hash" AKA "pound")."""
         self.assertTrue(is_channel('#channel'))
 
     def test_starts_with_plus(self):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,51 @@
 from unittest import TestCase
 
-from framewirc.parsers import nick
+from framewirc.parsers import is_channel, nick
+
+
+class TestIsChannel(TestCase):
+    """Tests for the boolean function is_channel."""
+    def test_starts_with_ampersand(self):
+        """True when starts with an & ("ampersand")."""
+        self.assertTrue(is_channel('&channel'))
+
+    def test_starts_with_exclamtion_mark(self):
+        """True when starts with an ! ("exclamation mark" AKA "bang")."""
+        self.assertTrue(is_channel('!channel'))
+
+    def test_starts_with_hash(self):
+        """True when starts with a # ("hash", AKA "pound")."""
+        self.assertTrue(is_channel('#channel'))
+
+    def test_starts_with_plus(self):
+        """True when starts with a + ("plus" AKA "add")."""
+        self.assertTrue(is_channel('+channel'))
+
+    def test_starts_with_alpha_char(self):
+        self.assertFalse(is_channel('channel'))
+
+    def test_50_chars(self):
+        """True when up to 50 chars."""
+        channel = '#' + 49 * 'a'
+        self.assertTrue(is_channel(channel))
+
+    def test_51_chars(self):
+        """False when 51 chars or more."""
+        channel = '#' + 50 * 'a'
+        self.assertFalse(is_channel(channel))
+
+    def test_contains_space(self):
+        """False when contains space."""
+        self.assertFalse(is_channel('#contains space'))
+
+    def test_contains_comma(self):
+        """False when contains comma."""
+        self.assertFalse(is_channel('#contains,comma'))
+
+    def test_contains_bel(self):
+        """False when contains ASCII BEL control char."""
+        # "\7" is one way python can escape the ASCII BEL char.
+        self.assertFalse(is_channel('#contains\7BEL'))
 
 
 class TestNick(TestCase):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -23,6 +23,7 @@ class TestIsChannel(TestCase):
         self.assertTrue(is_channel('+channel'))
 
     def test_starts_with_alpha_char(self):
+        """False when starts with a normal char."""
         self.assertFalse(is_channel('channel'))
 
     def test_50_chars(self):
@@ -94,6 +95,7 @@ class TestPrivmsg(TestCase):
         self.assertEqual(result['raw_sender'], 'nick!ident@host')
 
     def test_sender_nick(self):
+        """The `sender_nick` key is the sender's nick."""
         result = self.processed_message()
 
         self.assertEqual(result['sender_nick'], 'nick')


### PR DESCRIPTION
These should be useful for handlers. They can either be used to deconstruct messages in handlers themselves, or to make a handler decorator that passes the more semantic arguments into handlers that know what they're getting.
eg:

```python
def parse_privmsg(message):
    """Separate a PRIVMSG string into semantically named parts."""
    return {
        'text': message.suffix,
        'sender': message.prefix,
        'target': message.args[0],
    }
```

This could probably have a better name than `parse_privmsg`.