### PR TITLE
Ability to set default encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ once the API is stable.
 
 - ADDED: `utils.to_unicode` now takes encoding suggestions.
 
-  Preferred character encodings can now be passed into `to_unicode` in order.
+  An iterable of Preferred character encodings can now be passed in.
 
 ## v0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ once the API is stable.
   A function that splits a `PRIVMSG` command into a dictionary of semantically
   named attributes.
 
+- ADDED: `utils.to_unicode` now takes encoding suggestions.
+
+  Preferred character encodings can now be passed into `to_unicode` in order.
 
 ## v0.0.1
 

--- a/framewirc/utils.py
+++ b/framewirc/utils.py
@@ -54,8 +54,10 @@ def to_unicode(bytestring):
     try:
         return bytestring.decode()
     except UnicodeDecodeError:
-        charset = cchardet.detect(bytestring)['encoding'] or 'utf-8'
-        return bytestring.decode(charset, 'surrogateescape')
+        pass
+
+    charset = cchardet.detect(bytestring)['encoding'] or 'utf-8'
+    return bytestring.decode(encoding=charset, errors='surrogateescape')
 
 
 def to_bytes(string):

--- a/framewirc/utils.py
+++ b/framewirc/utils.py
@@ -46,7 +46,7 @@ class RequiredAttributesMixin:
 
 
 def to_unicode(bytestring):
-    """Try to decode as UTF8, then fall back to cchardet."""
+    """Try to convert a string of bytes into a unicode string."""
     # If we already have a unicode string, just return it.
     if isinstance(bytestring, str):
         return bytestring

--- a/framewirc/utils.py
+++ b/framewirc/utils.py
@@ -45,15 +45,11 @@ class RequiredAttributesMixin:
             raise exceptions.MissingAttributes(missing_attrs)
 
 
-def to_unicode(bytestring, *encodings):
+def to_unicode(bytestring, encodings=('utf8',)):
     """Try to convert a string of bytes into a unicode string."""
     # If we already have a unicode string, just return it.
     if isinstance(bytestring, str):
         return bytestring
-
-    # If no encodings were passed through, give utf8 a go.
-    if not encodings:
-        encodings = ('utf8',)
 
     # Try each of the encodings until no error is thrown.
     for encoding in encodings:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,12 @@ class TestToUnicode(TestCase):
         result = to_unicode(text)
         self.assertEqual(result, expected)
 
+    def test_utf8(self):
+        text = b"Rhoi'r ffidil yn y t\xc3\xb4"
+        expected = "Rhoi'r ffidil yn y tô"
+        result = to_unicode(text)
+        self.assertEqual(result, expected)
+
     def test_windows_1250(self):
         text = b'Miko\xb3aj Kopernik'
         expected = 'Mikołaj Kopernik'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,7 +53,7 @@ class TestToUnicode(TestCase):
         """
         An expected decoding can be wrong, and not throw errors.
 
-        Perhaps not "okay", but I don't know if it's possible to catch this.
+        Perhaps not ideal, but I don't know if it's possible to catch this.
         """
         text = b'Ume\xe5'
         expected = 'Umeĺ'  # Decoding incorrectly throws no error in this case

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,35 @@ class TestToUnicode(TestCase):
         with self.assertRaises(AttributeError):
             to_unicode(None)
 
+    def test_expected_decoding_first(self):
+        """
+        An undecoded bytestring will try "expected" before utf8.
+
+        This is because some non-UTF8 strings can be "valid" utf8.
+        """
+        text = b'\x1b$BEl5~ET\x1b(B'
+        expected = '東京都'  # as opposed to '\x1b$BEl5~ET\x1b(B'
+        result = to_unicode(text, 'iso-2022-jp')
+        self.assertEqual(result, expected)
+
+    def test_expected_decoding_quietly_wrong(self):
+        """
+        An expected decoding can be wrong, and not throw errors.
+
+        Perhaps not "okay", but I don't know if it's possible to catch this.
+        """
+        text = b'Ume\xe5'
+        expected = 'Umeĺ'  # Decoding incorrectly throws no error in this case
+        result = to_unicode(text, 'windows_1250')
+        self.assertEqual(result, expected)
+
+    def test_expected_decoding_loudly_wrong(self):
+        """An expected decoding can fall back to another encoding."""
+        text = b'\xff\xfe\xb5\x03\xbb\x03\xbb\x03\xb7\x03\xbd\x03\xb9\x03\xba\x03\xac\x03'
+        expected = 'ελληνικά'
+        result = to_unicode(text, 'iso-2022-jp', 'utf16')  # `text` is utf16
+        self.assertEqual(result, expected)
+
 
 class TestToBytes(TestCase):
     def test_unicode(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,7 @@ class TestToUnicode(TestCase):
         """
         text = b'\x1b$BEl5~ET\x1b(B'
         expected = '東京都'  # as opposed to '\x1b$BEl5~ET\x1b(B'
-        result = to_unicode(text, 'iso-2022-jp')
+        result = to_unicode(text, ['iso-2022-jp'])
         self.assertEqual(result, expected)
 
     def test_expected_decoding_quietly_wrong(self):
@@ -57,14 +57,14 @@ class TestToUnicode(TestCase):
         """
         text = b'Ume\xe5'
         expected = 'Umeĺ'  # Decoding incorrectly throws no error in this case
-        result = to_unicode(text, 'windows_1250')
+        result = to_unicode(text, ['windows_1250'])
         self.assertEqual(result, expected)
 
     def test_expected_decoding_loudly_wrong(self):
         """An expected decoding can fall back to another encoding."""
         text = b'\xff\xfe\xb5\x03\xbb\x03\xbb\x03\xb7\x03\xbd\x03\xb9\x03\xba\x03\xac\x03'
         expected = 'ελληνικά'
-        result = to_unicode(text, 'iso-2022-jp', 'utf16')  # `text` is utf16
+        result = to_unicode(text, ['iso-2022-jp', 'utf16'])  # `text` is utf16
         self.assertEqual(result, expected)
 
 


### PR DESCRIPTION
`to_unicode` should optionally take a default encoding. We could then fall back to the existing encoding detection code that we already have.