### PR TITLE
Add decorator that can handle more generic parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@ once the API is stable.
 
   A function to determine of a string is a valid channel name.
 
+- ADDED: `parsers.kwargs_to_kwargs`
+
+  A handler decorator that takes a parser, and passes the resulting dictionary
+  to the handler as kwargs. The parser should accept all kwargs.
+
 - ADDED: `parsers.message_to_kwargs`
 
   A handler decorator that takes a parser, and passes the resulting dictionary
-  to the handler as kwargs.
+  to the handler as kwargs. The parser should accept only a `message` kwarg.
 
 - ADDED: `parsers.nick`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ once the API is stable.
 
   A function to determine of a string is a valid channel name.
 
+- ADDED: `parsers.message_to_kwargs`
+
+  A handler decorator that takes a parser, and passes the resulting dictionary
+  to the handler as kwargs.
+
 - ADDED: `parsers.nick`.
 
   A function that takes a `nick!ident@host` string (or similar), and returns a
@@ -24,11 +29,6 @@ once the API is stable.
 
   A function that splits a `PRIVMSG` command into a dictionary of semantically
   named attributes.
-
-- ADDED: `parsers.to_kwargs`
-
-  A handler decorator that takes a parser, and passes the resulting dictionary
-  to the handler as kwargs.
 
 - ADDED: `utils.to_unicode` now takes encoding suggestions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@ once the API is stable.
   encoding. This is now left to the programmer to decide, allowing them to do
   things such as change default encoding per channel.
 
-- ADDED: `parsers.is_channel`.
-
-  A function to determine of a string is a valid channel name.
-
-- ADDED: `parsers.kwargs_to_kwargs`
+- ADDED: `parsers.apply_kwargs_parser`
 
   A handler decorator that takes a parser, and passes the resulting dictionary
   to the handler as kwargs. The parser should accept all kwargs.
 
-- ADDED: `parsers.message_to_kwargs`
+- ADDED: `parsers.apply_message_parser`
 
   A handler decorator that takes a parser, and passes the resulting dictionary
   to the handler as kwargs. The parser should accept only a `message` kwarg.
+
+- ADDED: `parsers.is_channel`.
+
+  A function to determine of a string is a valid channel name.
 
 - ADDED: `parsers.nick`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ quips = {
 
 
 @filters.command_whitelist(PRIVMSG)
-@parsers.to_kwargs(parsers.privmsg)
+@parsers.apply_kwargs_parser(parsers.privmsg)
 def snarky_response(client, channel, raw_body, **kwargs):
     body = to_unicode(raw_body)
 

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -80,7 +80,7 @@ def privmsg(message):
     }
 
 
-def kwargs_to_kwargs(parser):
+def apply_kwargs_parser(parser):
     """
     Decorator that passes the result of a kwargs parser to a handler as kwargs.
 
@@ -98,7 +98,7 @@ def kwargs_to_kwargs(parser):
     return inner_decorator
 
 
-def message_to_kwargs(parser):
+def apply_message_parser(parser):
     """
     Decorator that passes the result of a message parser to a handler as kwargs.
 

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -80,6 +80,24 @@ def privmsg(message):
     }
 
 
+def kwargs_to_kwargs(parser):
+    """
+    Decorator that passes the result of a kwargs parser to a handler as kwargs.
+
+    The parser needs to accept any number of kwargs.
+
+    Keys returned by the parser will overwrite those that the handler would
+    otherwise have received.
+    """
+    def inner_decorator(handler):
+        def wrapped(**kwargs):
+            parser_result = parser(**kwargs)
+            kwargs.update(parser_result)
+            handler(**kwargs)
+        return wrapped
+    return inner_decorator
+
+
 def message_to_kwargs(parser):
     """
     Decorator that passes the result of a message parser to a handler as kwargs.

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -80,8 +80,12 @@ def privmsg(message):
     }
 
 
-def to_kwargs(parser):
-    """Decorator that passes the result of a parser to a handler as kwargs."""
+def message_to_kwargs(parser):
+    """
+    Decorator that passes the result of a message parser to a handler as kwargs.
+
+    The parser will only be passed a `message` kwarg.
+    """
     def inner_decorator(handler):
         def wrapped(client, message):
             parser_result = parser(message=message)

--- a/framewirc/parsers.py
+++ b/framewirc/parsers.py
@@ -84,7 +84,7 @@ def to_kwargs(parser):
     """Decorator that passes the result of a parser to a handler as kwargs."""
     def inner_decorator(handler):
         def wrapped(client, message):
-            parser_result = parser(message)
+            parser_result = parser(message=message)
             handler(client=client, message=message, **parser_result)
         return wrapped
     return inner_decorator

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,7 +1,12 @@
 from unittest import mock, TestCase
 
 from framewirc.message import build_message, ReceivedMessage
-from framewirc.parsers import is_channel, nick, privmsg, to_kwargs
+from framewirc.parsers import (
+    is_channel,
+    message_to_kwargs,
+    nick,
+    privmsg,
+)
 
 
 class TestIsChannel(TestCase):
@@ -142,7 +147,11 @@ class TestPrivmsg(TestCase):
         self.assertTrue(result['third_person'])
 
 
-class TestToKwargs(TestCase):
+def parser_taking_message(message):
+    return {'key': 'value'}
+
+
+class TestMessageToKwargs(TestCase):
     def setUp(self):
         self.client = object()
         self.handler = mock.Mock()
@@ -150,17 +159,14 @@ class TestToKwargs(TestCase):
 
     def test_result_passed(self):
         """Dictionary returned from parser passed as kwargs."""
-        def returns_dict(message):
-            return {'derived_value': 'derived'}
-
-        wrapped = to_kwargs(returns_dict)(self.handler)
+        wrapped = message_to_kwargs(parser_taking_message)(self.handler)
 
         wrapped(client=self.client, message=self.message)
 
         self.handler.assert_called_once_with(
             client=self.client,
             message=self.message,
-            derived_value='derived',
+            key='value',
         )
 
     def test_parser_called_with_kwarg(self):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -2,9 +2,9 @@ from unittest import mock, TestCase
 
 from framewirc.message import build_message, ReceivedMessage
 from framewirc.parsers import (
+    apply_kwargs_parser,
+    apply_message_parser,
     is_channel,
-    kwargs_to_kwargs,
-    message_to_kwargs,
     nick,
     privmsg,
 )
@@ -152,7 +152,7 @@ def parser_taking_message(message):
     return {'key': 'value'}
 
 
-class TestMessageToKwargs(TestCase):
+class TestApplyMessageParser(TestCase):
     def setUp(self):
         self.client = object()
         self.handler = mock.Mock()
@@ -160,7 +160,7 @@ class TestMessageToKwargs(TestCase):
 
     def test_result_passed(self):
         """Dictionary returned from parser passed as kwargs."""
-        wrapped = message_to_kwargs(parser_taking_message)(self.handler)
+        wrapped = apply_message_parser(parser_taking_message)(self.handler)
 
         wrapped(client=self.client, message=self.message)
 
@@ -178,7 +178,7 @@ class TestMessageToKwargs(TestCase):
         parser is called with kwargs.
         """
         parser = mock.Mock(return_value={})
-        wrapped = message_to_kwargs(parser)(self.handler)
+        wrapped = apply_message_parser(parser)(self.handler)
         wrapped(client=self.client, message=self.message)
         parser.assert_called_once_with(message=self.message)
 
@@ -187,7 +187,7 @@ def parser_taking_kwargs(client, message, **kwargs):
     return {'key': 'value'}
 
 
-class TestKwargsToKwargs(TestCase):
+class TestApplyKwargsParser(TestCase):
     def setUp(self):
         self.client = object()
         self.handler = mock.Mock()
@@ -195,7 +195,7 @@ class TestKwargsToKwargs(TestCase):
 
     def test_result_passed(self):
         """Dictionary returned from parser passed as kwargs."""
-        wrapped = kwargs_to_kwargs(parser_taking_kwargs)(self.handler)
+        wrapped = apply_kwargs_parser(parser_taking_kwargs)(self.handler)
 
         wrapped(client=self.client, message=self.message)
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -3,6 +3,7 @@ from unittest import mock, TestCase
 from framewirc.message import build_message, ReceivedMessage
 from framewirc.parsers import (
     is_channel,
+    kwargs_to_kwargs,
     message_to_kwargs,
     nick,
     privmsg,
@@ -180,3 +181,26 @@ class TestMessageToKwargs(TestCase):
         wrapped = message_to_kwargs(parser)(self.handler)
         wrapped(client=self.client, message=self.message)
         parser.assert_called_once_with(message=self.message)
+
+
+def parser_taking_kwargs(client, message, **kwargs):
+    return {'key': 'value'}
+
+
+class TestKwargsToKwargs(TestCase):
+    def setUp(self):
+        self.client = object()
+        self.handler = mock.Mock()
+        self.message = object()
+
+    def test_result_passed(self):
+        """Dictionary returned from parser passed as kwargs."""
+        wrapped = kwargs_to_kwargs(parser_taking_kwargs)(self.handler)
+
+        wrapped(client=self.client, message=self.message)
+
+        self.handler.assert_called_once_with(
+            client=self.client,
+            message=self.message,
+            key='value',
+        )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -162,3 +162,15 @@ class TestToKwargs(TestCase):
             message=self.message,
             derived_value='derived',
         )
+
+    def test_parser_called_with_kwarg(self):
+        """
+        The parser is called with `message=message`.
+
+        It's not really a big deal, but it's slightly more flexible if the
+        parser is called with kwargs.
+        """
+        parser = mock.Mock(return_value={})
+        wrapped = message_to_kwargs(parser)(self.handler)
+        wrapped(client=self.client, message=self.message)
+        parser.assert_called_once_with(message=self.message)


### PR DESCRIPTION
I wasn't sure about the name `to_kwargs`, and I'm not sure about what I've replaced it with either...

I need more [hammock time](https://www.youtube.com/watch?v=f84n5oFoZBc) on this feature, I think.

Should these decorators even be in the `parsers` module?

Could also add a parser that takes a message and a dictionary of channel encodings, and returns the correctly decoded message string...?