### PR TITLE
Do not instanciate Task directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ once the API is stable.
 
   No longer falls over on nicks that are already just nicks (no ident, etc).
 
+- FIXED: `client.Client.connect_to`.
+
+  No longer directly instantiates `asycio.Task`. This allows custom loops to
+  customise `Task`. See #18.
+
 ## v0.1.0
 
 - CHANGED: Renamed `filters.command_blacklist` to `filters.deny`.

--- a/framewirc/client.py
+++ b/framewirc/client.py
@@ -14,7 +14,8 @@ class Client(utils.RequiredAttributesMixin):
     def connect_to(self, host, **kwargs):
         """Create a Connection. Handled in the event loop."""
         self.connection = self.connection_class(client=self, host=host, **kwargs)
-        return asyncio.Task(self.connection.connect())
+        loop = asyncio.get_event_loop()
+        return loop.create_task(self.connection.connect())
 
     def on_connect(self):
         """We're connected! Send our identity to the network!"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,14 +15,16 @@ class TestConnectTo:
     def test_connection_stored(self):
         """Has "connection" been stored on the client?"""
         client = BlankClient()
-        with mock.patch('asyncio.Task', spec=asyncio.Task):
+        mock_path = 'asyncio.BaseEventLoop.create_task'
+        with mock.patch(mock_path, spec=asyncio.Task):
             client.connect_to('irc.example.com')
         assert isinstance(client.connection, Connection)
 
     def test_task_returned(self):
         """Is the correct "Task" created and returned?"""
         client = BlankClient()
-        with mock.patch('asyncio.Task', spec=asyncio.Task) as Task:
+        mock_path = 'asyncio.BaseEventLoop.create_task'
+        with mock.patch(mock_path, spec=asyncio.Task) as Task:
             result = client.connect_to('irc.example.com')
         assert result == Task(client.connection.connect())
 


### PR DESCRIPTION
[We directly instanciate an instance of Task](https://github.com/meshy/framewirc/blob/651580eb4f74c412b7990907ad76ba7decc2d1b7/framewirc/client.py#L17) despite [warnings in the documentation not to do so](https://docs.python.org/3/library/asyncio-task.html#task). (Thanks to [this comment on `bottom`](https://github.com/numberoverzero/bottom/pull/16#discussion_r48680274) for pointing it out!)