### PR TITLE
Add python 3.6 to CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - "3.5"
+  - "3.6"
 install:
   - pip install -r requirements.txt
 script: "make test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ once the API is stable.
 ## Unreleased
 - REMOVED: Support for Python `3.4` has been removed.
 
+- ADDED: Support for Python `3.5` and `3.6` has been added.
+
 - ADDED: `client.Client.privmsg` now takes `third_person`.
 
   This can be used to send third person messages. (`/me likes this :D`)


### PR DESCRIPTION
Super premature, as python 3.6 is not yet released, nor supported by Travis.
