### PR TITLE
to_bytes raises incorrect error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ once the API is stable.
   No longer directly instantiates `asycio.Task`. This allows custom loops to
   customise `Task`. See #18.
 
+- FIXED: `utils.to_bytes` and `utils.to_unicode` now throw the correct error.
+
+  Previously, when passed an instance of the wrong type, these functions would
+  throw `AttributeError`. Now, correctly, they throw `TypeError`.
+
 ## v0.1.0
 
 - CHANGED: Renamed `filters.command_blacklist` to `filters.deny`.

--- a/framewirc/utils.py
+++ b/framewirc/utils.py
@@ -55,6 +55,9 @@ def to_unicode(bytestring, encodings=('utf8',)):
     for encoding in encodings:
         try:
             return bytestring.decode(encoding)
+        except AttributeError:
+            msg = '`bytestring` should be `ReceivedMessage` or `bytes`.'
+            raise TypeError(msg)
         except UnicodeDecodeError:
             continue
 
@@ -70,7 +73,8 @@ def to_bytes(string):
         return string.encode()
     except AttributeError:
         if not isinstance(string, bytes):
-            raise
+            msg = '`string` should be `unicode` or `bytes`.'
+            raise TypeError(msg)
         return string
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ class TestToUnicode:
         assert to_unicode(b'Miko\xb3aj Kopernik') == 'Mikołaj Kopernik'
 
     def test_not_bytes_or_string(self):
-        with pytest.raises(AttributeError):
+        with pytest.raises(TypeError):
             to_unicode(None)
 
     def test_expected_decoding_first(self):
@@ -59,7 +59,7 @@ class TestToBytes:
         assert to_bytes(text) == text
 
     def test_not_bytes_or_string(self):
-        with pytest.raises(AttributeError):
+        with pytest.raises(TypeError):
             to_bytes(None)
 
 


### PR DESCRIPTION
If `framewirc.utils.to_bytes` is presented something that is not a text type, it raises `AttibuteError`. This should in fact be `TypeError`.