### PR TITLE
Add join and part Client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ once the API is stable.
 
   This can be used to create third person messages. (`/me also likes this :D`)
 
+- ADDED: `client.Client.join`.
+
+- ADDED: `client.Client.part`.
+
 - FIXED: `parsers.nick`.
 
   No longer falls over on nicks that are already just nicks (no ident, etc).

--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ def my_simpler_command_handler(client, message):
 
 The `Client` has a couple of helper methods for sending commands to the
 network. You can send messages to users or channels with `Client.privmsg()`,
-and change your nick with `Client.set_nick()`. As there are a number of other
-very common actions, expect this part of the API to change and expand.
+and change your nick with `Client.set_nick()`. You can also join channels with
+`Client.join()` and leave them with `Client.part()`. As there are a number of
+other very common actions, expect this part of the API to change and expand.
 
 To send other messages to the network, you need to construct an appropriate
 byte string, and pass it to `Connection.send`. You will probably not want to do

--- a/framewirc/client.py
+++ b/framewirc/client.py
@@ -16,6 +16,11 @@ class Client(utils.RequiredAttributesMixin):
         loop = asyncio.get_event_loop()
         return loop.create_task(self.connection.connect())
 
+    def join(self, *channels):
+        """Join a number of channels."""
+        msg = build_message(commands.JOIN, ','.join(channels))
+        self.connection.send(msg)
+
     def on_connect(self):
         """We're connected! Send our identity to the network!"""
         nick = self.nick
@@ -27,6 +32,11 @@ class Client(utils.RequiredAttributesMixin):
         """Get a message from IRC and send it to all handlers."""
         for handler in self.handlers:
             handler(self, message)
+
+    def part(self, *channels, message=b''):
+        """Part from a number of channels (message optional)."""
+        msg = build_message(commands.PART, ','.join(channels), suffix=message)
+        self.connection.send(msg)
 
     def privmsg(self, target, message, third_person=False):
         self.connection.send_batch(make_privmsgs(target, message, third_person))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,6 +29,24 @@ class TestConnectTo:
         assert result == Task(client.connection.connect())
 
 
+class TestJoin:
+    """Test the Client.join() method."""
+    def setup_method(self, method):
+        """Can't make an IRC connection in tests, so a mock will have to do."""
+        self.client = BlankClient()
+        self.client.connection = mock.MagicMock(spec=Connection)
+
+    def test_singular(self):
+        """Can join a channel on a network."""
+        self.client.join('#framewirc')
+        self.client.connection.send.assert_called_with(b'JOIN #framewirc\r\n')
+
+    def test_multiple(self):
+        """Can join multiple channels simultaneously."""
+        self.client.join('#framewirc', '#meshy')
+        self.client.connection.send.assert_called_with(b'JOIN #framewirc,#meshy\r\n')
+
+
 class TestOnMessage:
     def test_handlers_called(self):
         """When a message comes in, it should be passed to the handlers."""
@@ -59,6 +77,31 @@ class TestOnConnect:
     def test_set_nick_called(self):
         self.client.on_connect()
         self.client.connection.send.assert_called_with(b'NICK anick\r\n')
+
+
+class TestPart:
+    """Test the Client.part() method."""
+    def setup_method(self, method):
+        """Can't make an IRC connection in tests, so a mock will have to do."""
+        self.client = BlankClient()
+        self.client.connection = mock.MagicMock(spec=Connection)
+
+    def test_singular(self):
+        """It's possible to leave a channel."""
+        self.client.part('#framewirc')
+        self.client.connection.send.assert_called_with(b'PART #framewirc\r\n')
+
+    def test_message(self):
+        """If provided with a parting message, pass it on."""
+        self.client.part('#framewirc', message='Leeroy Jenkins!')
+        expected = b'PART #framewirc :Leeroy Jenkins!\r\n'
+        self.client.connection.send.assert_called_with(expected)
+
+    def test_multiple(self):
+        """When passed multiple channels, leave them all."""
+        self.client.part('#framewirc', '#meshy')
+        expected = b'PART #framewirc,#meshy\r\n'
+        self.client.connection.send.assert_called_with(expected)
 
 
 class TestPrivmsg:


### PR DESCRIPTION
It'd be nice if we could call `client.join('#channel')` (and `part`) instead of having to build the command manually and pass it to `send`.