### PR TITLE
Account for relay prefix when sending messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ once the API is stable.
 
   This can be used to create third person messages. (`/me also likes this :D`)
 
+- ADDED: `message.make_privmsgs` now takes `mask_length`.
+
+  This accounts for the network added overhead (sender) on messages.
+
 - ADDED: `client.Client.join`.
 
 - ADDED: `client.Client.part`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ once the API is stable.
 
   Allows fine-tuning of sender mask overhead size for splitting messages.
 
+- ADDED: `handlers.capture_mask_length` (in `handlers.basic_handlers`).
+
+  This new handler passively fine-tunes the sender mask overhead based on
+  incoming messages.
+
 - ADDED: `client.Client.join`.
 
 - ADDED: `client.Client.part`.
@@ -53,6 +58,10 @@ once the API is stable.
 - FIXED: `messages.chunk_bytes` no longer loses spaces when splitting lines.
 
 - FIXED: `messages.chunk_bytes` no longer splits lines that fit exactly.
+
+- FIXED: `messages.make_privmsgs`.
+
+  Now properly accounts for network-added sender prefix.
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ once the API is stable.
 
   This accounts for the network added overhead (sender) on messages.
 
+- ADDED: `client.Client` now has `mask_length` attribute.
+
+  Allows fine-tuning of sender mask overhead size for splitting messages.
+
 - ADDED: `client.Client.join`.
 
 - ADDED: `client.Client.part`.

--- a/framewirc/client.py
+++ b/framewirc/client.py
@@ -9,6 +9,7 @@ class Client(utils.RequiredAttributesMixin):
     """Handle events from Connection and offer methods for sending data."""
     connection_class = Connection
     required_attributes = ('handlers', 'real_name', 'nick')
+    mask_length = None
 
     def connect_to(self, host, **kwargs):
         """Create a Connection. Handled in the event loop."""
@@ -39,7 +40,13 @@ class Client(utils.RequiredAttributesMixin):
         self.connection.send(msg)
 
     def privmsg(self, target, message, third_person=False):
-        self.connection.send_batch(make_privmsgs(target, message, third_person))
+        messages = make_privmsgs(
+            target,
+            message,
+            third_person=third_person,
+            mask_length=self.mask_length,
+        )
+        self.connection.send_batch(messages)
 
     def set_nick(self, new_nick):
         """Set a nick on the network."""

--- a/framewirc/client.py
+++ b/framewirc/client.py
@@ -52,3 +52,5 @@ class Client(utils.RequiredAttributesMixin):
         """Set a nick on the network."""
         self.connection.send(build_message(commands.NICK, new_nick))
         self.nick = new_nick
+        # As soon as the nick changes, reset mask_length.
+        self.mask_length = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,7 +169,7 @@ class TestSetNick:
     """Test the Client.set_nick() method."""
     def setup_method(self, method):
         """Can't make an IRC connection in tests, so a mock will have to do."""
-        self.client = BlankClient()
+        self.client = BlankClient(mask_length=42)
         self.client.connection = mock.MagicMock(spec=Connection)
 
     def test_command_sent(self):
@@ -182,3 +182,8 @@ class TestSetNick:
         new_nick = 'meshy'
         self.client.set_nick(new_nick)
         assert self.client.nick == new_nick
+
+    def test_mask_length_reset(self):
+        """When the nick changes, reset the mask_length."""
+        self.client.set_nick('meshy')
+        assert self.client.mask_length is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,6 +133,21 @@ class TestPrivmsg:
         expected = [b'PRIVMSG #channel :\1ACTION is speaking in 3rd person!\1\r\n']
         client.connection.send_batch.assert_called_once_with(expected)
 
+    def test_mask_length(self):
+        mask_length = mock.Mock()
+        client = BlankClient(mask_length=mask_length)
+        client.connection = mock.MagicMock(spec=Connection)
+        message = 'We know the size of the mask!'
+        with mock.patch('framewirc.client.make_privmsgs') as make_privmsgs:
+            client.privmsg('#channel', message)
+
+        make_privmsgs.assert_called_once_with(
+            '#channel',
+            message,
+            third_person=False,
+            mask_length=mask_length,
+        )
+
 
 class TestRequiredFields:
     """Test to show that RequiredAttribuesMixin is properly configured."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,6 +3,8 @@ from unittest import mock
 from framewirc import handlers
 from framewirc.messages import ReceivedMessage
 
+from .utils import BlankClient
+
 
 class TestPing:
     def test_ping(self):
@@ -42,3 +44,64 @@ class TestBadNick:
         handlers.nickname_in_use(client, message)
 
         assert client.set_nick.called is False
+
+
+class TestCaptureMaskLength:
+    def test_length_known(self):
+        """If the mask_length is already known, skip."""
+        client = BlankClient(mask_length=42, nick='user')
+        mask = b'user!~mask@should.never.change'  # Except when nick does.
+        raw_message = b':%s PRIVMSG #channel :Message ignored'
+        message = ReceivedMessage(raw_message % mask)
+
+        handlers.capture_mask_length(client, message)
+
+        # We shouldn't have started the calculation at all, let alone changed
+        # the value of client.mask_length.
+        assert client.mask_length != len(mask)
+
+    def test_privmsg(self):
+        """Determine mask length from PRIVMSGs sent by ourself."""
+        client = BlankClient(mask_length=None, nick='nick')
+        mask = b'nick!~user@host.example.com'
+        raw_message = b':%s PRIVMSG #channel :Message ignored'
+        message = ReceivedMessage(raw_message % mask)
+
+        handlers.capture_mask_length(client, message)
+
+        assert client.mask_length == len(mask)
+
+    def test_notice(self):
+        """Determine mask length from NOTICEs sent by ourself."""
+        client = BlankClient(mask_length=None, nick='nick')
+        mask = b'nick!~user@host.example.com'
+        raw_message = b':%s NOTICE #channel :Message ignored'
+        message = ReceivedMessage(raw_message % mask)
+
+        handlers.capture_mask_length(client, message)
+
+        assert client.mask_length == len(mask)
+
+    def test_rpl_whoisuser(self):
+        """If we WHOIS ourself, we can get the mask length from that."""
+        client = BlankClient(mask_length=None, nick='nick')
+
+        # Mask has spaces in RPL_WHOISUSER. We need the the params (excluding
+        # the `*`). ie:             |<----------------------->| == 27 chars
+        raw_message = b':server 311 nick ~user host.example.com * :Real name'
+        message = ReceivedMessage(raw_message)
+
+        handlers.capture_mask_length(client, message)
+
+        assert client.mask_length == 27  # (See comment on raw_message.)
+
+    def test_other(self):
+        """Do not respond to other commands."""
+        client = BlankClient(mask_length=None, nick='nick')
+        mask = b'nick!~user@host.example.com'
+        raw_message = b':%s OTHER #channel :Message ignored'
+        message = ReceivedMessage(raw_message % mask)
+
+        handlers.capture_mask_length(client, message)
+
+        assert client.mask_length is None

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -281,7 +281,7 @@ class TestMakePrivMsgs:
         with mock.patch('framewirc.messages.chunk_message') as chunk_message:
             make_privmsgs('meshy', msg, mask_length=200)
 
-        # 293 = 512 - len(b': PRIVMSG meshy :' + b'\r\n') - 200
+        # 293 = 512 - len(b': PRIVMSG meshy :\r\n') - 200
         chunk_message.assert_called_with(msg, max_length=293)
 
     def test_third_person(self):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -234,7 +234,7 @@ class TestMakePrivMsgs:
     def test_long_line(self):
         too_long = (
             "We're no strangers to love, You know the rules and so do I. " +
-            "A full commitment's what I'm thinking of, You wouldnt get " +
+            "A full commitment's what I'm thinking of, You wouldn't get " +
             "this from any other guy. I just wanna tell you how I'm " +
             "feeling, Gotta make you understand… Never gonna give you up, " +
             "Never gonna let you down, Never gonna run around and desert " +
@@ -248,7 +248,7 @@ class TestMakePrivMsgs:
             (
                 b"PRIVMSG meshy :We're no strangers to love, You know the " +
                 b"rules and so do I. A full commitment's what I'm thinking " +
-                b"of, You wouldnt get this from any other guy. I just wanna " +
+                b"of, You wouldn't get this from any other guy. I just wanna " +
                 b"tell you how I'm feeling, Gotta make you " +
                 b"understand\xe2\x80\xa6 Never gonna give you up, Never " +
                 b"gonna let you down, Never gonna run around and desert " +

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -253,13 +253,13 @@ class TestMakePrivMsgs:
                 b"understand\xe2\x80\xa6 Never gonna give you up, Never " +
                 b"gonna let you down, Never gonna run around and desert " +
                 b"you. Never gonna make you cry, Never gonna say goodbye, " +
-                b"Never gonna tell a lie and hurt you. We've known each " +
-                b"other for so long your heart's been aching but you're too " +
-                b"shy to say it. Inside we both \r\n"
+                b"Never gonna tell a lie and hurt you. \r\n"
             ),
             (
-                b"PRIVMSG meshy :know what's been going on, We know the " +
-                b"game and we're gonna play it.\r\n"
+                b"PRIVMSG meshy :We've known each other for so long your " +
+                b"heart's been aching but you're too shy to say it. Inside " +
+                b"we both know what's been going on, We know the game and " +
+                b"we're gonna play it.\r\n"
             ),
         ]
 
@@ -272,8 +272,17 @@ class TestMakePrivMsgs:
         with mock.patch('framewirc.messages.chunk_message') as chunk_message:
             make_privmsgs('meshy', msg)
 
-        expected_max = 495  # 512 - len(b'PRIVMSG meshy :' + b'\r\n')
-        chunk_message.assert_called_with(msg, max_length=expected_max)
+        # 393 = 512 - len(': PRIVMSG meshy :\r\n') - 100
+        chunk_message.assert_called_with(msg, max_length=393)
+
+    def test_prefix_allowance(self):
+        """Is the correct max_length calculated when prefix passed?"""
+        msg = 'A test message'
+        with mock.patch('framewirc.messages.chunk_message') as chunk_message:
+            make_privmsgs('meshy', msg, mask_length=200)
+
+        # 293 = 512 - len(b': PRIVMSG meshy :' + b'\r\n') - 200
+        chunk_message.assert_called_with(msg, max_length=293)
 
     def test_third_person(self):
         """Are third person messages marked?"""
@@ -287,5 +296,5 @@ class TestMakePrivMsgs:
         with mock.patch('framewirc.messages.chunk_message') as chunk_message:
             make_privmsgs('meshy', msg, third_person=True)
 
-        expected_max = 486  # 512 - len(b'PRIVMSG meshy :\1ACTION ' + b'\1\r\n')
-        chunk_message.assert_called_with(msg, max_length=expected_max)
+        # 384 = 512 - len(b': PRIVMSG meshy :\1ACTION \1\r\n') - 100
+        chunk_message.assert_called_with(msg, max_length=384)


### PR DESCRIPTION
This allows for the relay prefix (AKA mask) that servers add to messages. Without this, messages might be silently dropped for being too long, even if they were short enough when transmitted.

We assume 100 chars for the messages will be enough, but we can control this if the true size of the mask is known.

To determine the true size of the mask, we handle `PRIVMSG` and `NOTICE` from ourselves, and replies to a `/whois` on ourselves (`RPL_WHOISUSER`). This is then cached on the `Client` object as `mask_length`.

Fixes #21. Needs to be manually tested before merging. Best reviewed one commit at a time.