### PR TITLE
Make chunk_message more efficient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache
 .coverage
+.hypothesis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ once the API is stable.
   Previously, when passed an instance of the wrong type, these functions would
   throw `AttributeError`. Now, correctly, they throw `TypeError`.
 
+- FIXED: `messages.chunk_bytes` no longer splits lines that fit exactly.
+
 ## v0.1.0
 
 - CHANGED: Renamed `filters.command_blacklist` to `filters.deny`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ once the API is stable.
   Previously, when passed an instance of the wrong type, these functions would
   throw `AttributeError`. Now, correctly, they throw `TypeError`.
 
+- FIXED: `messages.chunk_bytes` no longer loses spaces when splitting lines.
+
 - FIXED: `messages.chunk_bytes` no longer splits lines that fit exactly.
 
 ## v0.1.0

--- a/framewirc/messages.py
+++ b/framewirc/messages.py
@@ -89,7 +89,7 @@ def _chunk_message(message, max_length):
         spacepoint = line_bytes.rfind(b' ', 0, max_length+1)
         if spacepoint != -1:
             # Break on the last space that fits.
-            start = line_bytes[:spacepoint]
+            start = line_bytes[:(spacepoint + 1)]
             yield start
             # ... and add what's left back into the line pool.
             end = line_bytes[(spacepoint + 1):].decode()

--- a/framewirc/messages.py
+++ b/framewirc/messages.py
@@ -79,7 +79,7 @@ def _chunk_message(message, max_length):
     lines = deque(message.splitlines())
     while lines:
         line = lines.popleft()
-        line_bytes = to_bytes(line)
+        line_bytes = line.encode()
         # If the line fits, add it the the lines.
         if len(line_bytes) < max_length:
             yield line_bytes
@@ -90,7 +90,7 @@ def _chunk_message(message, max_length):
         spacepoint = None  # Where we should break if there is a space.
         line_length = 0  # The running total size of the line
         for i, str_char in enumerate(line):
-            char_length = len(to_bytes(str_char))
+            char_length = len(str_char.encode())
             line_length += char_length
             if str_char == ' ':
                 spacepoint = i
@@ -101,15 +101,14 @@ def _chunk_message(message, max_length):
         if spacepoint is not None:
             # Break on the last space that fits.
             start = line[:spacepoint]
-            yield to_bytes(start)
+            yield start.encode()
             # ... and add what's left back into the line pool.
             end = line[(spacepoint + 1):]
             lines.appendleft(end)
             continue
-
         # Whole line does not contain spaces, so split within word.
         start = line[:letterpoint]
-        yield to_bytes(start)
+        yield start.encode()
         end = line[letterpoint:]
         lines.appendleft(end)
 

--- a/framewirc/messages.py
+++ b/framewirc/messages.py
@@ -101,24 +101,25 @@ def _chunk_message(message, max_length):
         chunk_bytes = line_bytes[:max_length]
         b1, b2, b3, b4 = chunk_bytes[:max_length][-4:]
 
-        if (  # Last character doesn't cross the boundary.
+        # Last character doesn't cross the boundary.
+        if (
             b4 >> 7 == 0b0 or  # 1-byte char.
             b3 >> 5 == 0b110 or  # 2-byte char.
             b2 >> 4 == 0b1110 or  # 3-byte char.
             b1 >> 3 == 0b11110  # 4-byte char.
         ):
             offset = 0
-        elif (  # b4 begins a char crossing the boundary.
-            b4 >> 6 == 0b11  # 2-, 3-, or 4-byte char.
-        ):
+
+        # b4 begins a char crossing the boundary.
+        elif b4 >> 6 == 0b11:  # 2-, 3-, or 4-byte char.
             offset = 1
-        elif (  # b3 begins a char crossing the boundary.
-            b3 >> 5 == 0b111  # 3- or 4-byte char.
-        ):
+
+        # b3 begins a char crossing the boundary.
+        elif b3 >> 5 == 0b111:  # 3- or 4-byte char.
             offset = 2
-        else:
-            # b2 must begin a 4-byte char crossing the boundary.
-            # ie: b2 >> 4 == 0b11110
+
+        # b2 must begin a 4-byte char crossing the boundary.
+        else:  # ie: b2 >> 4 == 0b11110
             offset = 3
 
         yield chunk_bytes[:max_length-offset]

--- a/framewirc/messages.py
+++ b/framewirc/messages.py
@@ -81,7 +81,7 @@ def _chunk_message(message, max_length):
         line = lines.popleft()
         line_bytes = line.encode()
         # If the line fits, add it the the lines.
-        if len(line_bytes) < max_length:
+        if len(line_bytes) <= max_length:
             yield line_bytes
             continue
 

--- a/framewirc/messages.py
+++ b/framewirc/messages.py
@@ -80,7 +80,7 @@ def _chunk_message(message, max_length):
     while lines:
         line = lines.popleft()
         line_bytes = line.encode()
-        # If the line fits, add it the the lines.
+        # If the line fits, add it to the accepted lines.
         if len(line_bytes) <= max_length:
             yield line_bytes
             continue

--- a/framewirc/utils.py
+++ b/framewirc/utils.py
@@ -29,8 +29,7 @@ class RequiredAttributesMixin:
     name.
     """
     def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        self.__dict__.update(kwargs)
 
         missing_attrs = []
         for attr in self.required_attributes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@
 coverage==4.2.0
 flake8==3.0.4
 isort==4.2.5
+hypothesis==3.44.26
 pytest==3.0.4
 pytest-greendots==0.3

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -174,6 +174,24 @@ class TestChunkMessage:
         ]
         assert chunk_message(msg, max_length=20) == expected
 
+    @pytest.mark.parametrize(
+        'max_length,message',
+        product(
+            [4, 5, 6, 7],
+            (
+                'øøøøøøøøøø',  # 2-byte
+                '。。。。。。。。。。',  # 3-byte
+                '💩💩💩💩💩💩💩💩💩💩',  # 4-byte
+            ),
+        ),
+    )
+    def test_split_mid_char(self, max_length, message):
+        """Check all permutations of mid-char breaks."""
+        # The string chunks up without error.
+        result = chunk_message(message, max_length=max_length)
+        # When rejoined, the original string is restored.
+        assert ''.join(map(bytes.decode, result)) == message
+
 
 class TestMakePrivMsgs:
     """Ensure make_privmsgs correctly constructs PRIVMSG command lists."""

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -146,9 +146,9 @@ class TestChunkMessage:
         """Does it split long lines?"""
         msg = 'Message to be split into chunks of twenty characters or less.'
         expected = [
-            b'Message to be split',
-            b'into chunks of',
-            b'twenty characters or',
+            b'Message to be split ',
+            b'into chunks of ',
+            b'twenty characters or ',
             b'less.',
         ]
         assert chunk_message(msg, max_length=20) == expected
@@ -157,7 +157,7 @@ class TestChunkMessage:
         """Does it split long words?"""
         msg = 'Sup Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch?'
         expected = [
-            b'Sup',
+            b'Sup ',
             b'Llanfairpwllgwyngyll',
             b'gogerychwyrndrobwlll',
             b'lantysiliogogogoch?',
@@ -255,7 +255,7 @@ class TestMakePrivMsgs:
                 b"you. Never gonna make you cry, Never gonna say goodbye, " +
                 b"Never gonna tell a lie and hurt you. We've known each " +
                 b"other for so long your heart's been aching but you're too " +
-                b"shy to say it. Inside we both\r\n"
+                b"shy to say it. Inside we both \r\n"
             ),
             (
                 b"PRIVMSG meshy :know what's been going on, We know the " +

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -164,6 +164,12 @@ class TestChunkMessage:
         ]
         assert chunk_message(msg, max_length=20) == expected
 
+    def test_exact_length(self):
+        """Lines are not split unless it's required."""
+        msg = 'Exact.'
+        expected = [b'Exact.']
+        assert chunk_message(msg, max_length=len(msg)) == expected
+
     def test_split_long_unicode(self):
         """Are words with multi-byte chars split correctly?"""
         # Repeated failures lead to success.

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -174,17 +174,14 @@ class TestChunkMessage:
         ]
         assert chunk_message(msg, max_length=20) == expected
 
-    @pytest.mark.parametrize(
-        'max_length,message',
-        product(
-            [4, 5, 6, 7],
-            (
-                'øøøøøøøøøø',  # 2-byte
-                '。。。。。。。。。。',  # 3-byte
-                '💩💩💩💩💩💩💩💩💩💩',  # 4-byte
-            ),
-        ),
+    _multibyte_strings = (
+        'øøøøøøøøøø',  # 2-byte
+        '。。。。。。。。。。',  # 3-byte
+        '💩💩💩💩💩💩💩💩💩💩',  # 4-byte
     )
+    _variations = product([4, 5, 6, 7], _multibyte_strings)
+
+    @pytest.mark.parametrize('max_length,message', _variations)
     def test_split_mid_char(self, max_length, message):
         """Check all permutations of mid-char breaks."""
         # The string chunks up without error.


### PR DESCRIPTION
It was really slow before.

- `to_bytes` turns out to be pretty bad in a tight loop.
- We jumped straight into searching one char at a time before trying to split on space. (`rfind` is significantly faster.)

There's a little more that can be done here before merging. Mostly, I'm not a fan of looping over the chars one at a time. It's seriously inefficient. Most of the time, we're not going to find what we're looking for in the first few hundred iterations.

A binary search would be much better. I think we can also be more efficient about the minimum and maximum bounds based on the unicode restrictions, and the max length.

Note to future self: look into the [`bisect`](https://docs.python.org/3.6/library/bisect.html) module to see if it can abstract away rolling our own binary search.