### PR TITLE
Make tests more informative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,26 @@
 SHELL := /bin/bash
 
+RED := \033[0;31m
+GREEN := \033[0;32m
+PURPLE := \033[1;35m
+RESET := \033[0m
+FAILURE := (echo -e "${RED}FAILURE${RESET}" && exit 1)
+SUCCESS := echo -e "${GREEN}SUCCESS${RESET}"
+RESULT := && ${SUCCESS} || ${FAILURE}
+
 help:
 	@echo "Usage:"
 	@echo " make test | Run the tests."
 
 test:
-	@coverage run -m py.test
-	@coverage report
-	@flake8
-	@isort --check
+	@echo -e "${PURPLE}Run tests:${RESET}"
+	@coverage run -m py.test ${RESULT}
+	@echo -e "\n${PURPLE}Check for untested code:${RESET}"
+	@coverage report ${RESULT}
+	@echo -e "\n${PURPLE}Check for flake8 violations:${RESET}"
+	@flake8 ${RESULT}
+	@echo -e "\n${PURPLE}Check for unsorted imports:${RESET}"
+	@isort --check ${RESULT}
 
 release:
 	python setup.py register sdist bdist_wheel upload

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ coverage==4.2.0
 flake8==3.0.4
 isort==4.2.5
 hypothesis==3.44.26
-pytest==3.0.4
-pytest-greendots==0.3
+pytest==3.4.1


### PR DESCRIPTION
The separate tests are now colorfully delineated. Their success or failure is also now explicit.

The warnings emitted during a test run are now clearly visible again, and pytest now outputs a percentage (as is the default). An unfortunate side-effect of upgrading pytest for the warnings output is that pytest-greendots broke.

Related to #27.

![screenshot from 2018-03-05 21-14-15](https://user-images.githubusercontent.com/767671/37000108-3804e118-20ba-11e8-9dcf-462e2435eb5c.png)
